### PR TITLE
Show previous entries on this date under the Calendar view

### DIFF
--- a/src/get-daily-notes.ts
+++ b/src/get-daily-notes.ts
@@ -198,6 +198,25 @@ export function getPriorNotes(allNotes: TFile[], plugin: Diarian, referenceMomen
     return filteredNotes;
 }
 
+export function getNotesOnThisDayAcrossYears(allNotes: TFile[], folder: string, format: string, referenceMoment: moment.Moment) {
+    const refMonth = referenceMoment.month();
+    const refDate = referenceMoment.date();
+    const refYear = referenceMoment.year();
+
+    let filteredNotes: TFile[] = [];
+
+    for (let note of allNotes) {
+        const noteDate = getMoment(note, folder, format);
+        const isSameMonthDay = noteDate.month() == refMonth && noteDate.date() == refDate;
+        const isDifferentYear = noteDate.year() != refYear;
+        if (isSameMonthDay && isDifferentYear) {
+            filteredNotes.push(note);
+        }
+    }
+
+    return filteredNotes;
+}
+
 export function getModifiedFolderAndFormat(settings: DiarianSettings) {
     let { format, folder }: any = getDailyNoteSettings();
     if (settings.overrideFolder) {

--- a/src/get-daily-notes.ts
+++ b/src/get-daily-notes.ts
@@ -138,8 +138,8 @@ export function isSameDay(date1: moment.Moment, date2: moment.Moment) {
         && date1.year() == date2.year());
 }
 
-export function getPriorNotes(allNotes: TFile[], plugin: Diarian) {
-    const now = moment().endOf('day');
+export function getPriorNotes(allNotes: TFile[], plugin: Diarian, referenceMoment?: moment.Moment) {
+    const now = (referenceMoment ?? moment()).clone().endOf('day');
 
     // printToConsole(logLevel.log, now.format('MMMM Do, YYYY [at] h:mm:ss.SSS A'));
     const reviewInterval = plugin.settings.reviewInterval;

--- a/src/main.ts
+++ b/src/main.ts
@@ -585,7 +585,7 @@ export default class Diarian extends Plugin {
             for (let leaf of revView) {
                 let view = leaf.view;
                 if (view instanceof OnThisDayView) {
-                    view.refresh(this);
+                    view.refresh(this, startMoment?.toDate());
                 }
             }
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -202,6 +202,7 @@ export interface DiarianSettings {
 
     onThisDayLoc: LeafType;
     onThisDayStartup: boolean;
+    onThisDaySyncSelectedDate: boolean;
 
     dateStampFormat: string;
     timeStampFormat: string;
@@ -250,6 +251,7 @@ export const DEFAULT_SETTINGS: DiarianSettings = {
 
     onThisDayLoc: 'right' as LeafType,
     onThisDayStartup: false,
+    onThisDaySyncSelectedDate: false,
 
     dateStampFormat: 'M/D/YYYY',
     timeStampFormat: 'h:mm A',
@@ -793,6 +795,26 @@ export class DiarianSettingTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.onThisDayStartup).onChange((value) => {
                     this.plugin.settings.onThisDayStartup = value;
                     void this.plugin.saveSettings();
+                }));
+
+        //#endregion
+
+        //#region Sync to selected date
+        const syncOnThisDayDesc = new DocumentFragment;
+        syncOnThisDayDesc.textContent = 'Show notes relative to the ';
+        syncOnThisDayDesc.createEl('strong', { text: "Calendar" });
+        syncOnThisDayDesc.appendText("'s currently selected date, instead of always showing today's date.");
+
+        new Setting(containerEl)
+            .setName('Sync to selected date')
+            .setDesc(syncOnThisDayDesc)
+            .addToggle((toggle) =>
+                toggle.setValue(this.plugin.settings.onThisDaySyncSelectedDate).onChange((value) => {
+                    this.plugin.settings.onThisDaySyncSelectedDate = value;
+                    void this.plugin.saveSettings();
+                    if (!value) {
+                        this.plugin.refreshViews(false, true, moment());
+                    }
                 }));
 
         //#endregion

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -186,6 +186,7 @@ export interface DiarianSettings {
     calRotateImages: boolean;
     calImageRotationInterval: number;
     calStartup: boolean;
+    calShowPastYears: boolean;
 
     previewLength: number;
     openInNewPane: boolean;
@@ -235,6 +236,7 @@ export const DEFAULT_SETTINGS: DiarianSettings = {
     calImageRotationInterval: 1,
     calLocation: 'tab' as LeafType.tab,
     calStartup: false,
+    calShowPastYears: true,
 
     previewLength: 250,
     openInNewPane: false,
@@ -621,6 +623,26 @@ export class DiarianSettingTab extends PluginSettingTab {
                     .onChange((value) => {
                         this.plugin.settings.calStartup = value;
                         void this.plugin.saveSettings();
+                    }));
+        //#endregion
+
+        //#region Show past years
+        const pastYearsDesc = new DocumentFragment;
+        pastYearsDesc.textContent = 'Show a list of notes from the same calendar date in past years, directly under the ';
+        pastYearsDesc.createEl('strong', { text: "Calendar" });
+        pastYearsDesc.appendText(" view.");
+
+        new Setting(containerEl)
+            .setName('Show past years')
+            .setDesc(pastYearsDesc)
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(this.plugin.settings.calShowPastYears)
+                    .onChange((value) => {
+                        this.plugin.settings.calShowPastYears = value;
+                        void this.plugin.saveSettings();
+                        this.plugin.refreshViews(true, false);
+                        this.display();
                     }));
         //#endregion
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -628,12 +628,12 @@ export class DiarianSettingTab extends PluginSettingTab {
 
         //#region Show past years
         const pastYearsDesc = new DocumentFragment;
-        pastYearsDesc.textContent = 'Show a list of notes from the same calendar date in past years, directly under the ';
+        pastYearsDesc.textContent = 'Show a list of notes from the selected date in past years, directly under the ';
         pastYearsDesc.createEl('strong', { text: "Calendar" });
         pastYearsDesc.appendText(" view.");
 
         new Setting(containerEl)
-            .setName('Show past years')
+            .setName('Display past notes')
             .setDesc(pastYearsDesc)
             .addToggle((toggle) =>
                 toggle
@@ -825,7 +825,7 @@ export class DiarianSettingTab extends PluginSettingTab {
         const syncOnThisDayDesc = new DocumentFragment;
         syncOnThisDayDesc.textContent = 'Show notes relative to the ';
         syncOnThisDayDesc.createEl('strong', { text: "Calendar" });
-        syncOnThisDayDesc.appendText("'s currently selected date, instead of always showing today's date.");
+        syncOnThisDayDesc.appendText("'s selected date instead of today.");
 
         new Setting(containerEl)
             .setName('Sync to selected date')

--- a/src/views/react-nodes/calendar-view.tsx
+++ b/src/views/react-nodes/calendar-view.tsx
@@ -8,7 +8,7 @@ import { App, ItemView, WorkspaceLeaf, TFile, View, moment } from "obsidian";
 import { Root, createRoot } from "react-dom/client";
 import { Calendar, OnArgs } from 'react-calendar';
 import type Diarian from 'src/main';
-import { getMoments, getNoteByMoment, isSameDay, getModifiedFolderAndFormat } from "src/get-daily-notes";
+import { getMoments, getMoment, getNoteByMoment, isSameDay, getModifiedFolderAndFormat, getNotesOnThisDayAcrossYears } from "src/get-daily-notes";
 import NotePreview from './note-preview';
 import { ViewType, printToConsole, logLevel } from 'src/constants';
 import { NewDailyNote } from "./new-note";
@@ -275,6 +275,44 @@ const CalendarContainer = ({ view, plugin, app, thisComp, monthStep }: Container
         showNotesNode = <p>There are no notes on this day.</p>;
     }
 
+    let pastYearsNode;
+    if (plugin.settings.calShowPastYears) {
+        const { folder, format }: any = getModifiedFolderAndFormat(plugin.settings);
+        const pastYearNotes = getNotesOnThisDayAcrossYears(dailyNotes, folder, format, moment(selectedDate));
+
+        if (pastYearNotes.length !== 0) {
+            pastYearNotes.sort((fileA, fileB) => {
+                const momentA = getMoment(fileA, folder, format);
+                const momentB = getMoment(fileB, folder, format);
+                return momentB.diff(momentA);
+            });
+
+            let groups: { year: number; notes: TFile[] }[] = [];
+            for (let note of pastYearNotes) {
+                const noteYear = getMoment(note, folder, format).year();
+                const lastGroup = groups[groups.length - 1];
+                if (lastGroup && lastGroup.year === noteYear) {
+                    lastGroup.notes.push(note);
+                } else {
+                    groups.push({ year: noteYear, notes: [note] });
+                }
+            }
+
+            pastYearsNode = groups.map((group) => (
+                <div key={group.year}>
+                    <h2>{group.year}</h2>
+                    {group.notes.map((note) => (
+                        <div key={note.name}>
+                            <NotePreview note={note} view={view} plugin={plugin} app={app} />
+                        </div>
+                    ))}
+                </div>
+            ));
+        } else {
+            pastYearsNode = <p>No notes from past years on this day.</p>;
+        }
+    }
+
     function newDailyNote() {
         new NewDailyNote(app, plugin, moment(selectedDate)).open();
     }
@@ -419,6 +457,12 @@ const CalendarContainer = ({ view, plugin, app, thisComp, monthStep }: Container
             <div className='note-preview-container'>
                 {showNotesNode}
             </div>
+            {plugin.settings.calShowPastYears && (
+                <div className='note-preview-container cal-past-years-container'>
+                    <h1>Previous entries on this date</h1>
+                    {pastYearsNode}
+                </div>
+            )}
         </div>
     )
 };

--- a/src/views/react-nodes/calendar-view.tsx
+++ b/src/views/react-nodes/calendar-view.tsx
@@ -181,6 +181,9 @@ const CalendarContainer = ({ view, plugin, app, thisComp, monthStep }: Container
     function outerSetDate(nextDate: Date) {
         innerSetDate(nextDate);
         thisComp.startDate = nextDate;
+        if (plugin.settings.onThisDaySyncSelectedDate) {
+            plugin.refreshViews(false, true, moment(nextDate));
+        }
     }
 
     function tileContent({ date, view }: any) {

--- a/src/views/react-nodes/calendar-view.tsx
+++ b/src/views/react-nodes/calendar-view.tsx
@@ -309,7 +309,7 @@ const CalendarContainer = ({ view, plugin, app, thisComp, monthStep }: Container
                 </div>
             ));
         } else {
-            pastYearsNode = <p>No notes from past years on this day.</p>;
+            pastYearsNode = <p>There are no notes from past years on this day.</p>;
         }
     }
 
@@ -459,7 +459,7 @@ const CalendarContainer = ({ view, plugin, app, thisComp, monthStep }: Container
             </div>
             {plugin.settings.calShowPastYears && (
                 <div className='note-preview-container cal-past-years-container'>
-                    <h1>Previous entries on this date</h1>
+                    <h1>Previous notes on this day</h1>
                     {pastYearsNode}
                 </div>
             )}

--- a/src/views/react-nodes/on-this-day-view.tsx
+++ b/src/views/react-nodes/on-this-day-view.tsx
@@ -1,5 +1,5 @@
 import { StrictMode } from "react";
-import { App, ItemView, WorkspaceLeaf, TFile, View } from "obsidian";
+import { App, ItemView, WorkspaceLeaf, TFile, View, moment } from "obsidian";
 import { Root, createRoot } from "react-dom/client";
 import type Diarian from 'src/main';
 import { ViewType } from 'src/constants';
@@ -11,17 +11,20 @@ interface ContainerProps {
     view: View;
     plugin: Diarian;
     app: App;
+    referenceMoment: moment.Moment;
 }
 
 export class OnThisDayView extends ItemView {
     root: Root | null = null;
     plugin: Diarian;
     app: App;
+    referenceDate: Date;
 
     constructor(leaf: WorkspaceLeaf, plugin: Diarian, app: App) {
         super(leaf);
         this.plugin = plugin;
         this.app = app;
+        this.referenceDate = new Date();
     }
 
     getViewType() {
@@ -39,7 +42,7 @@ export class OnThisDayView extends ItemView {
             <StrictMode>
                 <div className='on-this-day-container'>
                     <h1>On this day...</h1>
-                    <ReviewContainer view={this} plugin={this.plugin} app={this.app} />
+                    <ReviewContainer view={this} plugin={this.plugin} app={this.app} referenceMoment={moment(this.referenceDate)} />
                 </div>
             </StrictMode>
         );
@@ -50,8 +53,9 @@ export class OnThisDayView extends ItemView {
     }
 
 
-    async refresh(plugin: Diarian) {
+    async refresh(plugin: Diarian, newDate?: Date) {
         this.plugin = plugin;
+        if (newDate !== undefined) this.referenceDate = newDate;
         this.onClose();
         this.onOpen();
     }
@@ -59,8 +63,8 @@ export class OnThisDayView extends ItemView {
 }
 
 
-const ReviewContainer = ({ view, plugin, app }: ContainerProps) => {
-    let filteredNotes = getPriorNotes(plugin.dailyNotes, plugin);
+const ReviewContainer = ({ view, plugin, app, referenceMoment }: ContainerProps) => {
+    let filteredNotes = getPriorNotes(plugin.dailyNotes, plugin, referenceMoment);
     if (!filteredNotes || filteredNotes.length == 0) {
         return (
             <p>No notes to show.</p>
@@ -112,7 +116,7 @@ const ReviewContainer = ({ view, plugin, app }: ContainerProps) => {
     return (
         <div className='note-preview-container' >
             {array.map(({ notes, moment, id }) => (
-                <TimeSpan key={id} notes={notes} thisMoment={moment} view={view} plugin={plugin} app={app} />
+                <TimeSpan key={id} notes={notes} thisMoment={moment} referenceMoment={referenceMoment} view={view} plugin={plugin} app={app} />
             ))}
         </div>
     );

--- a/src/views/react-nodes/time-span.tsx
+++ b/src/views/react-nodes/time-span.tsx
@@ -6,18 +6,19 @@ import type Diarian from 'src/main';
 interface Props {
     notes: TFile[];
     thisMoment: moment.Moment;
+    referenceMoment: moment.Moment;
     /* wrapper?: React.JSX.Element; */
     view: View;
     plugin: Diarian;
     app: App;
 }
 
-export const TimeSpan = ({ notes, thisMoment, /* wrapper, */ view, plugin, app }: Props) => {
+export const TimeSpan = ({ notes, thisMoment, referenceMoment, /* wrapper, */ view, plugin, app }: Props) => {
     const unit = plugin.settings.reviewIntervalUnit;
     // printToConsole(logLevel.log, thisMoment.toString());
 
 
-    const now = moment().endOf('day');
+    const now = referenceMoment.clone().endOf('day');
 
     if (!notes.length) {
         return null;


### PR DESCRIPTION
Adds an optional "Show past years" setting that lists notes from the
same calendar date in past years directly under the Calendar view,
grouped by year.

Part of #92.